### PR TITLE
Plot results no required timestamp

### DIFF
--- a/scripts/visualization/examples/CSV/category.csv
+++ b/scripts/visualization/examples/CSV/category.csv
@@ -1,0 +1,7 @@
+temperature,class,anomalyScore
+,test sample for string data,
+,skipping these 2 lines,
+18.1,"normal",0.1
+18.9,"normal",0.2
+25,"high",0.5
+99,"danger",0.99

--- a/scripts/visualization/examples/CSV/sin_30sec.csv
+++ b/scripts/visualization/examples/CSV/sin_30sec.csv
@@ -1,4 +1,4 @@
-timestamp,function,anomaly_score
+time,function,anomaly_score
 0.0,0.0,1.0
 0.05,0.30901699,1.0
 0.1,0.58778525,1.0

--- a/scripts/visualization/index.html
+++ b/scripts/visualization/index.html
@@ -111,5 +111,9 @@
         </div>
       </div>
     </div>
+    <div>
+      <label>Use time as x-axis</label>
+      <input type=checkbox onClick="toggleUseTime()" id="chkUseTime" accesskey=c />
+    </div>
   </body>
 </html>

--- a/scripts/visualization/opf_visualizer.js
+++ b/scripts/visualization/opf_visualizer.js
@@ -321,6 +321,7 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
     }
   };
 
+
   // the main "graphics" is rendered here
   $scope.renderData = function() {
     var fields = [];
@@ -395,6 +396,16 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
   });
 
 }]);
+
+//TODO: you'll be able to integrate this better in the UI
+var useTime;
+function toggleUseTime() {
+  useTime = document.getElementById("chkUseTime").checked;
+  if (useTime) { // use time for x-axis
+    alert(useTime);
+    TIMESTAMP = TIMESTAMP_OPF;
+  }
+}
 
 angular.module('app').directive('fileUploadChange', function() {
   return {

--- a/scripts/visualization/opf_visualizer.js
+++ b/scripts/visualization/opf_visualizer.js
@@ -144,9 +144,9 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
               fieldValue = NONE_VALUE_REPLACEMENT;
               continue;
             }
-            //TODO: uncheck by default the parseString'ed columns (the values can be quite highi), or better, normalize them.
             //FIXME: in OPF the number of columns in data and fields (=labels) is off
-            fieldValue = parseString(fieldValue); // ..as a String = used for Categories data
+            fieldValue = parseString(fieldValue);
+            fieldValue = parseCategory(columnName, fieldValue); // ..as a String = used for Categories data
         }
         arr.push(fieldValue);
       }
@@ -204,7 +204,6 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
   // parseString()
   // hash any string to an integer number
   // return: numeric representation (hash) of the string
-  // TODO: add parseCategory that uses parseString but maps to {1,2,3,...}
   var parseString = function(str){
         var hash = 0;
         if (str.length == 0) return hash;
@@ -215,6 +214,36 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
         }
         return hash;
   }
+
+  // parseCategory()
+  // for given group (grpId) make a mapping from 
+  // "wild spread" integers to "small values".
+  // Eg. {1, 2345, 9999} -> {1, 2, 3}
+  // return: reduced "small" integer for given group
+  var grps = {};
+  var parseCategory = function (grpId, num) {
+      var id = String(grpId);
+      num = String(num);
+      if (!(id in grps)) {
+          grps[id] = []; // add new grp
+      }
+      var arr = grps[id];
+      if (arr.indexOf(num) === -1) {
+          arr.push(num);
+          //alert('push '+num);
+      }
+      return arr.indexOf(num);
+  };
+  /*
+  //test
+  alert(parseCategory('name', 2)); //0
+  alert(parseCategory('name', 2)); //0
+  alert(parseCategory('name', 2)); //0
+  alert(parseCategory('name', 3)); //1
+  alert(parseCategory('name', 500)); //2
+  alert(parseCategory('n', 2)); //0
+  alert(parseCategory('n', 22)); //1
+  */
 
   // normalize select field with regards to the Data choice.
   $scope.normalizeField = function(normalizedFieldId) {

--- a/scripts/visualization/opf_visualizer.js
+++ b/scripts/visualization/opf_visualizer.js
@@ -201,6 +201,7 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
   // parseString()
   // hash any string to an integer number
   // return: numeric representation (hash) of the string
+  // TODO: add parseCategory that uses parseString but maps to {1,2,3,...}
   var parseString = function(str){
         var hash = 0;
         if (str.length == 0) return hash;

--- a/scripts/visualization/opf_visualizer.js
+++ b/scripts/visualization/opf_visualizer.js
@@ -123,8 +123,9 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
   var convertPapaToDyGraph = function(data) {
     // strip out the rows (meta data) from header
     data.splice(0, HEADER_SKIPPED_ROWS);
-    // use the last row in the dataset to determine the data types
-    var map = generateFieldMap(data[data.length - 1], EXCLUDE_FIELDS);
+    // determine the data types
+    var lastDataRow = data[data.length - 1];
+    var map = generateFieldMap(lastDataRow, EXCLUDE_FIELDS);
     if (map === null) {
       handleError("Failed to parse the uploaded CSV file!", "danger");
       return null;
@@ -132,8 +133,9 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
     for (var rowId = 0; rowId < data.length; rowId++) {
       var arr = [];
       for (var colId = 0; colId < loadedFields.length; colId++) {
-        var fieldValue = data[rowId][loadedFields[colId]]; // numeric
-        if (colId === 0) { // this should always be the timestamp. See generateFieldMap
+        var columnName = loadedFields[colId];
+        var fieldValue = data[rowId][columnName]; // numeric
+        if (columnName === TIMESTAMP) { // special handling for timestamp
           if (typeof(fieldValue) === "number") {
             date = fieldValue;
           } else if (typeof(fieldValue) === "string") {

--- a/scripts/visualization/opf_visualizer.js
+++ b/scripts/visualization/opf_visualizer.js
@@ -1,10 +1,14 @@
 // some Settings:
 
 // TIMESTAMP:
-// represents the name of the column with timestamp/x-data;
+// represents the name of the column with timestamp/x-axis;
 // currently such column must be present in the data, and be of ISO Date format.
-// TODO: allow numeric or missing timestamp column ?
-var TIMESTAMP = "timestamp";
+// reserved value DEFAULT_XAXIS means use (automatically added) iteration step for x-axis
+// any other value means use this column as x-axis
+// TODO: add radio-choice "x-axis" among the (Data, Normalize) to change this? Or just checkbox 'Use time as X axis'?
+var DEFAULT_XAXIS = "__ITER__"; 
+var TIMESTAMP_OPF = "timestamp";
+var TIMESTAMP = DEFAULT_XAXIS;
 
 // EXCLUDE_FIELDS:
 // used to ignore some fields completely, not showing them as possibilities in graph plots.
@@ -125,10 +129,10 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
       for (var colId = 0; colId < loadedFields.length; colId++) {
         var columnName = loadedFields[colId];
         var fieldValue = data[rowId][columnName]; // numeric
-        if (columnName === "Iteration") { // iteration used for x-axis column
-          fieldValue = rowId; 
-        } else { // process other data columns (can be numeric/date/string(=category))
-          if (typeof(fieldValue) === "string") { // handle string data
+        if (columnName === DEFAULT_XAXIS) { // iteration used for x-axis column
+          fieldValue = rowId;
+        // process other data columns (can be numeric/date/string(=category))
+        } else if (typeof(fieldValue) === "string") { // handle string data
             var date = parseDate(fieldValue); // ..as Date
             if (date !== null) { // parsing succeeded, use it
               fieldValue = date;
@@ -143,7 +147,6 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
             //TODO: uncheck by default the parseString'ed columns (the values can be quite highi), or better, normalize them.
             //FIXME: in OPF the number of columns in data and fields (=labels) is off
             fieldValue = parseString(fieldValue); // ..as a String = used for Categories data
-          }
         }
         arr.push(fieldValue);
       }
@@ -293,11 +296,11 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
   // return: matrix with numeric/string/date columns
   var generateFieldMap = function(row, excludes) {
     angular.forEach(row, function(value, key) {
-      if (excludes.indexOf(key) === -1) {
+      if (excludes.indexOf(key) === -1 && key !== TIMESTAMP) { // TIMESTAMP is added later below
         loadedFields.push(key);
       }
     });
-    loadedFields.unshift("Iteration"); // add column Iteration for x-data
+    loadedFields.unshift(TIMESTAMP); // column for x-data
     return loadedFields;
   };
 
@@ -332,7 +335,7 @@ angular.module('app').controller('AppCtrl', ['$scope', '$timeout', function($sco
     var counter = 0;
     for (var i = 0; i < renderedFields.length; i++) {
       var field = renderedFields[i]; 
-      if (field === "Iteration") { // skip
+      if (field === TIMESTAMP) { // skip
         continue;
       } 
       $scope.view.fieldState.push({


### PR DESCRIPTION
This PR does quite big changes to https://github.com/numenta/nupic/issues/2658 and needs some improving, but I've managed nice cleanups & new functionality: 
- [x] timestamp is not a required (and 1st column) field - useful for generic CSV
  - [ ] x-axis is now iteration - not sure if feature/bug - WIP: possible to choose - a checkbox
- [x] allow all types of columns (numeric/date/string) - I think useful for a lot of applications, eg NLP tasks
  - [ ] need to fix different count between fields(labels) and data columns in OPF
  - [x] improve `string->number` conversion (use categories to make the values smaller)
  - [ ] for each column we could keep a structure `{type: (numeric/date/string); plotMethod: (different for string data)`
- [x] added testing examples

CC @jefffohl
